### PR TITLE
callback may has multiple arguments

### DIFF
--- a/chrome-promise.js
+++ b/chrome-promise.js
@@ -45,7 +45,11 @@
             if (err) {
               reject(err);
             } else {
-              resolve.apply(null, arguments);
+              if (arguments.length === 1) {
+                resolve(arguments[0]);
+              } else {
+                resolve(arguments);
+              }
             }
           }
 

--- a/chrome-promise.js
+++ b/chrome-promise.js
@@ -45,7 +45,7 @@
             if (err) {
               reject(err);
             } else {
-              if (arguments.length === 1) {
+              if (arguments.length <= 1) {
                 resolve(arguments[0]);
               } else {
                 resolve(arguments);


### PR DESCRIPTION
Most of chrome.* API 's callback only has one argument, but someone not, for example:[chrome.hid.receive(integer connectionId, function callback)](https://developer.chrome.com/apps/hid#method-receive)

And, the native `resolve()` function only accept one argument, even though `resolve.apply(null, arguments )`.

So below code only get the first argument:

```js
var cp = new ChromePromise();
var connectionId = 4;

cp.hid.receive( connectionId ).then( function( reportId, data ) {
  console.log( reportId ); // 3
  console.log( data ); // undefined
}  );
```

I think when callback has multiple argumnets, we need put the whole `arguments` like `resolve(arguments)` but not `resolve.apply(null,arguments)`.

So the above code will be:

```js
var cp = new ChromePromise();
var connectionId = 4;

cp.hid.receive( connectionId ).then( function( args ) {
  var reportId = args[0];
  var data = args[1];
  console.log( reportId ); // 3
  console.log( data ); // ArrayBuffer
}  );
```