### PR TITLE
Make fillProperties resilient to deprecated methods

### DIFF
--- a/chrome-promise.js
+++ b/chrome-promise.js
@@ -91,7 +91,17 @@
     function fillProperties(source, target) {
       for (var key in source) {
         if (hasOwnProperty.call(source, key)) {
-          var val = source[key];
+          var val;
+          // Sometime around Chrome v71, certain deprecated methods on the
+          // extension APIs started using proxies to throw an error if the
+          // deprecated methods were accessed, regardless of whether they
+          // were invoked or not.  That would cause this code to throw, even
+          // if no one was actually invoking that method.
+          try {
+            val = source[key];
+          } catch(err) {
+           continue;
+          }
           var type = typeof val;
 
           if (type === 'object' && !(val instanceof ChromePromise)) {

--- a/test/schema.json
+++ b/test/schema.json
@@ -469,10 +469,7 @@
         "getViews",
         "isAllowedFileSchemeAccess",
         "isAllowedIncognitoAccess",
-        "setUpdateUrlData",
-        "sendRequest",
-        "onRequest",
-        "onRequestExternal"
+        "setUpdateUrlData"
       ]
     },
     "fontSettings": {

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,11 @@ var expect = chai.expect;
 
 var chrome = require('sinon-chrome');
 chrome.runtime.id = 'foo123';  // Fix for schema.json
+
+// Some time around Chrome 71, extension.sendRequest (and a few others) started
+// throwing an error when accessed.  This mimics that behavior.
+Object.defineProperty(chrome.extension, 'sendRequest', { get: function() { throw new Error('Deprecated!'); }}); 
+
 var ChromePromise = require('../constructor');
 
 describe('ChromePromise', function() {
@@ -42,7 +47,6 @@ describe('ChromePromise', function() {
     it('has the same schema as chrome', function() {
       expect(chromep).to.have.jsonSchema(require('./schema.json'));
     });
-
 
     describe('.tabs.create', function() {
       it('returns a promise', function() {


### PR DESCRIPTION
Some time around Chrome 71, chrome started throwing an error when
certain methods were accessed.  To fix this, we came up with 3
solutions:

 - Blacklist certain properties
 - try/catch around the accessor
 - Use a proxy to lazy-evaluate methods

The last approach is probably ideal, but outside the scope of what I
have time for, so I opted for the second choice.